### PR TITLE
add missing csp domains

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -14,11 +14,13 @@
         <policy id="style-src-elem">
             <values>
                 <value id="datareporter-webcache" type="host">https://webcache.datareporter.eu</value>
+                <value id="datareporter-webcache-eu" type="host">https://webcache-eu.datareporter.eu</value>
             </values>
         </policy>
         <policy id="script-src-elem">
             <values>
                 <value id="datareporter" type="host">webcache.datareporter.eu</value>
+                <value id="datareporter-webcache-eu" type="host">webcache-eu.datareporter.eu</value>
             </values>
         </policy>
         <policy id="connect-src">


### PR DESCRIPTION
Some domains are missing in the existing csp rules. This small patch adds the domains I found to be missing.